### PR TITLE
Add Markdown tables support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5608,6 +5608,11 @@
         "@mixmark-io/domino": "^2.2.0"
       }
     },
+    "turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="
+    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-draggable": "^4.4.6",
     "react-joyride": "^2.7.2",
     "turndown": "^7.1.1",
+    "turndown-plugin-gfm": "^1.0.2",
     "usehooks-ts": "^2.9.1",
     "uuid": "^8.3.2"
   },

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import compareVersions from "compare-versions";
 import ReactDOM from "react-dom";
 import Turndown from "turndown";
+const turndownPluginGfm = require('turndown-plugin-gfm')
 import { Readability } from "@mozilla/readability";
 
 import Button from "@mui/material/Button";
@@ -171,6 +172,8 @@ if (!document.getElementById(ROOT_CONTAINER_ID)) {
     >("loading");
 
     const turndown = new Turndown(TurndownConfiguration);
+
+    turndown.use(turndownPluginGfm.gfm);
 
     useEffect(() => {
       if (


### PR DESCRIPTION
###### Overview:

This PR introduces a small yet impactful change to enhance the parsing of tables within our markdown files. By integrating the turndown-gfm-plugin, we can now successfully parse HTML tables, ensuring that they are converted into clean and readable markdown format.

###### Key Changes:

	•	Integrated turndown-gfm-plugin to handle the parsing of HTML tables.
	•	Improved markdown output by converting HTML tables into well-structured markdown tables, enhancing readability and consistency.

###### Impact:

This update will make our markdown files look better by ensuring that tables are properly formatted and displayed. It should be particularly useful for documents where tabular data is frequently used.
