### PR TITLE
✨ feat(handlebars): add helper to remove backticks

### DIFF
--- a/src/handlebars.ts
+++ b/src/handlebars.ts
@@ -43,6 +43,10 @@ Handlebars.registerHelper("uuid", (): string => {
   return uuid();
 });
 
+Handlebars.registerHelper("removeBackticks", (content: string): string => {
+  return content.replace(/`/g, "");
+});
+
 const render = (request: SandboxRenderRequest): SandboxRenderResponse => {
   const compiled = Handlebars.compile(request.template, { noEscape: true });
 


### PR DESCRIPTION
Adds capability to pre-process content with backticks, per #214 

Testing a locally running version of the extension and my live obsidian vault / Open AI key, the page is captured correctly, and the summaries are generated by Templater with no issues.

This is the url I tested with: https://towardsdatascience.com/how-i-won-singapores-gpt-4-prompt-engineering-competition-34c195a93d41

Here is the result:
![image](https://github.com/user-attachments/assets/ba3e31e6-eea6-43a3-871e-3df200f3f4c9)
